### PR TITLE
Update os_cpu.S

### DIFF
--- a/source/os_cpu.S
+++ b/source/os_cpu.S
@@ -1,0 +1,34 @@
+/* ------------- assembler directives -----------------------------*/
+    .syntax unified
+    .thumb
+
+
+/* ------------- public functions definitions ---------------------*/
+    .globl      PendSV_Handler
+
+
+/* ------------- public variable definitions ----------------------*/
+    .globl      OS_TCBCurrent
+    .globl      OS_TCBNext
+
+
+/* ------------- public functions declarations --------------------*/
+    .thumb_func
+PendSV_Handler:
+    PUSH      {R4-R11}
+
+    /* save current sp */
+    LDR       R0, =OS_TCBCurrent
+    LDR       R0, [R0]
+    CBZ       R0, PendSV_noSave
+
+    STR       SP, [R0]
+PendSV_noSave:
+    /* restore next sp */
+    LDR       R0, =OS_TCBNext
+    LDR       R0, [R0]
+    LDR       SP, [R0]
+
+    POP       {R4-R11}
+
+    BX        LR


### PR DESCRIPTION
restored the last version of os_cpu.
We did that because we had problems with Eclipse not recognizing assembler scripts with lower case extension '.s'. Now we have '.S'.